### PR TITLE
feat: configure structlog to output to stderr instead of stdout

### DIFF
--- a/src/augments_mcp/server.py
+++ b/src/augments_mcp/server.py
@@ -9,6 +9,7 @@ import os
 import asyncio
 from typing import List, Dict, Any, Optional
 from contextlib import asynccontextmanager
+import sys
 import structlog
 from mcp.server.fastmcp import FastMCP, Context
 from fastmcp.exceptions import ToolError
@@ -41,13 +42,13 @@ from .tools.updates import (
 # Load environment variables from .env file
 load_dotenv()
 
-# Configure structured logging
+# Configure structured logging to use stderr
 structlog.configure(
     processors=[
         structlog.dev.ConsoleRenderer()
     ],
     wrapper_class=structlog.make_filtering_bound_logger(20),  # INFO level
-    logger_factory=structlog.PrintLoggerFactory(),
+    logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),  # Send to stderr
     cache_logger_on_first_use=True,
 )
 


### PR DESCRIPTION
## Problem

Claude Desktop on Mac was interpreting the logs on stdout as input. Changing the logs to go to stderr stops this issue, while still allowing the output to be captured in Claude Desktop's logs.

## Screenshots

On starting Claude Desktop:

<img width="2032" height="1114" alt="image" src="https://github.com/user-attachments/assets/28c339ff-20d9-4ee9-8e73-fdb654496db9" />

On talking to Augment:

<img width="2032" height="1114" alt="image" src="https://github.com/user-attachments/assets/90a713d1-6d83-45f3-a18b-c15a3d24d927" />

## Tests

All tests passed. As no new functionality was added in this PR, no new tests were added.