### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ Set `GITHUB_TOKEN` for higher GitHub API rate limits when fetching examples and 
 @augments scan_project_deps
 ```
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/augmnt-augments-mcp-server).
+
 ## Tools
 
 | Tool | Description |


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/augmnt-augments-mcp-server).